### PR TITLE
Return no intersecting ranges if there are no overlaps (max level = 1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,10 @@
       return Math.max(max, p.count);
     }, 0);
 
+    if (ranges.length > 1 && maxCount === 1) {
+      return [];
+    }
+
     // Remove all starting points that are not at the max intersection count,
     // then create interval with starting value and its next neigbor as end value
     return points

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intersecting-ranges",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Find intersecting ranges using Marzullo algorithm",
   "main": "index.js",
   "repository": "git@github.com:hampusohlsson/intersecting-ranges.git",


### PR DESCRIPTION
Fixes #1 